### PR TITLE
Implement parallel substitution

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,15 +73,14 @@ const resolve = async (projectId, secretName) => {
  * @param {string} projectId
  */
 const substitute = async projectId => {
-  for (const envvar in process.env) {
-    if (
-      process.env.hasOwnProperty(envvar) &&
-      process.env[envvar].startsWith(BERGLAS_PREFIX)
-    ) {
-      const element = process.env[envvar];
-      let decrypted = await resolve(projectId, element);
-      process.env[envvar] = decrypted;
-    }
+  const resolved = await Promise.all(
+    Object.entries(process.env)
+      .filter(([_, element]) => element.startsWith(BERGLAS_PREFIX))
+      .map(async ([key, element]) => [key, await resolve(projectId, element)])
+  );
+
+  for (const [key, element] of resolved) {
+    process.env[key] = element;
   }
 };
 


### PR DESCRIPTION
Promise.all on the resolve requests, converting an O(N) operation to a (close to) O(1).

Figured out how to fix #4 without too many changes. Hope you like it.

There are no tests, but I did some manual tests myself and for just 3 secrets the difference Is quite big:

> sync substitute 5150.181ms
> async substitute 1737.905ms


